### PR TITLE
Add $install_database parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,14 +13,17 @@ class logcheck(
   $logcheck_sortuniq='0',
   $logcheck_support_cracking_ignore='0',
   $logcheck_syslogsummary='0',
+  $install_database=true,
 ) {
   # install package
   package { "logcheck":
     ensure => present,
   }
 
-  package { "logcheck-database":
-    ensure => present,
+  if $install_database {
+    package { "logcheck-database":
+      ensure => present,
+    }
   }
 
 


### PR DESCRIPTION
In some setups it is not desired to have the rules from logcheck-database installed.
With the new parameter $install_database (default: true) it can be controlled if logcheck-database is installed.
